### PR TITLE
Some Simplifications

### DIFF
--- a/MissingAssetsFinder.Lib/Finder.cs
+++ b/MissingAssetsFinder.Lib/Finder.cs
@@ -107,8 +107,9 @@ namespace MissingAssetsFinder.Lib
             return s;
         }
 
-        private void TryAdd(ISkyrimMajorRecordGetter record, string file)
+        private void TryAdd(ISkyrimMajorRecordGetter record, string? file)
         {
+            if (file == null) return;
             if (_blackList.Contains(record.FormKey.ID))
                 return;
             // ToLower is just for clean visualization
@@ -191,85 +192,42 @@ namespace MissingAssetsFinder.Lib
         {
             mod.Armors.Records.NotNull().Do(r =>
             {
-                var femaleFile = r.WorldModel?.Female?.Model?.File;
-                if (!femaleFile.IsEmpty())
-                {
-                    TryAdd(r, femaleFile!);
-                }
-
-                var maleFile = r.WorldModel?.Male?.Model?.File;
-                if (!maleFile.IsEmpty())
-                {
-                    TryAdd(r, maleFile!);
-                }
+                TryAdd(r, r.WorldModel?.Female?.Model?.File);
+                TryAdd(r, r.WorldModel?.Male?.Model?.File);
             });
 
             mod.TextureSets.Records.Do(r =>
             {
-                if (!r.Diffuse.IsEmpty())
-                {
-                    TryAdd(r, r.Diffuse!);
-                }
-
-                if (!r.NormalOrGloss.IsEmpty())
-                {
-                    TryAdd(r, r.NormalOrGloss!);
-                }
-
-                if (!r.EnvironmentMaskOrSubsurfaceTint.IsEmpty())
-                {
-                    TryAdd(r, r.EnvironmentMaskOrSubsurfaceTint!);
-                }
-
-                if (!r.GlowOrDetailMap.IsEmpty())
-                {
-                    TryAdd(r, r.GlowOrDetailMap!);
-                }
-
-                if (!r.Height.IsEmpty())
-                {
-                    TryAdd(r, r.Height!);
-                }
-
-                if (!r.Environment.IsEmpty())
-                {
-                    TryAdd(r, r.Environment!);
-                }
-
-                if (!r.Multilayer.IsEmpty())
-                {
-                    TryAdd(r, r.Multilayer!);
-                }
-
-                if (!r.BacklightMaskOrSpecular.IsEmpty())
-                {
-                    TryAdd(r, r.BacklightMaskOrSpecular!);
-                }
+                TryAdd(r, r.Diffuse);
+                TryAdd(r, r.NormalOrGloss);
+                TryAdd(r, r.EnvironmentMaskOrSubsurfaceTint);
+                TryAdd(r, r.GlowOrDetailMap);
+                TryAdd(r, r.Height);
+                TryAdd(r, r.Environment);
+                TryAdd(r, r.Multilayer);
+                TryAdd(r, r.BacklightMaskOrSpecular);
             });
 
             mod.Weapons.Records
-                .Where(r => r.Model != null)
                 .Do(r =>
                 {
-                    TryAdd(r, r.Model!.File);
+                    TryAdd(r, r.Model?.File);
                 });
 
             mod.Statics.Records
-                .Where(r => r.Model != null).Do(r =>
+                .Do(r =>
                 {
-                    TryAdd(r, r.Model!.File);
+                    TryAdd(r, r.Model?.File);
                 });
 
             mod.HeadParts.Records.Do(r =>
             {
-                if (r.Model != null)
-                    TryAdd(r, r.Model.File);
+                TryAdd(r, r.Model?.File);
 
                 r.Parts
-                    .Where(p => !p.FileName.IsEmpty())
                     .Do(p =>
                     {
-                        TryAdd(r, p.FileName!);
+                        TryAdd(r, p.FileName);
                     });
             });
 

--- a/MissingAssetsFinder.Lib/Finder.cs
+++ b/MissingAssetsFinder.Lib/Finder.cs
@@ -164,41 +164,6 @@ namespace MissingAssetsFinder.Lib
             0x7 //Player
         };
 
-        public class FormKeyComparer : Comparer<FormKey>
-        {
-            public int Compare(FormKey x, FormKey y, LoadOrder<ISkyrimModDisposableGetter> loadOrder)
-            {
-                if (!loadOrder.TryGetListing(x.ModKey,
-                    out (LoadOrderIndex Index, ModListing<ISkyrimModDisposableGetter> Listing) resultX))
-                    return Compare(x, y);
-
-                if (!loadOrder.TryGetListing(y.ModKey,
-                    out (LoadOrderIndex Index, ModListing<ISkyrimModDisposableGetter> Listing) resultY))
-                    return Compare(x, y);
-
-                if (resultX.Index.ID.CompareTo(resultY.Index.ID) != 0)
-                    return resultX.Index.ID.CompareTo(resultY.Index.ID);
-
-                return Compare(x, y);
-            }
-
-            public override int Compare(FormKey x, FormKey y)
-            {
-
-                if (string.Compare(x.ModKey.FileName, y.ModKey.FileName, StringComparison.Ordinal) != 0)
-                {
-                    return string.Compare(x.ModKey.FileName, y.ModKey.FileName, StringComparison.Ordinal);
-                }
-
-                if (x.ID.CompareTo(y.ID) != 0)
-                {
-                    return x.ID.CompareTo(y.ID);
-                }
-
-                return 0;
-            }
-        }
-
         public void FindMissingAssets(bool useLoadOrder)
         {
             if (!useLoadOrder)
@@ -221,7 +186,7 @@ namespace MissingAssetsFinder.Lib
             _loadOrder.Select(x => x.Mod).NotNull().Do(mod => FindMissingAssets(mod, linkCache));
             Utils.Log($"Finished finding missing assets for {mods.Count} mods");
 
-            MissingAssets.Sort((x, y) => new FormKeyComparer().Compare(x.Record.FormKey, y.Record.FormKey, _loadOrder));
+            MissingAssets.Sort((x, y) => FormKey.LoadOrderComparer(_loadOrder).Compare(x.Record.FormKey, y.Record.FormKey));
         }
 
         public void FindMissingAssets(string plugin)

--- a/MissingAssetsFinder.Lib/MissingAssetsFinder.Lib.csproj
+++ b/MissingAssetsFinder.Lib/MissingAssetsFinder.Lib.csproj
@@ -9,7 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="JetBrains.Annotations" Version="2020.1.0" />
-    <PackageReference Include="Mutagen.Bethesda" Version="0.5.0" />
+    <PackageReference Include="Mutagen.Bethesda" Version="0.8.0" />
   </ItemGroup>
 
 </Project>

--- a/MissingAssetsFinder/MainWindowVM.cs
+++ b/MissingAssetsFinder/MainWindowVM.cs
@@ -120,7 +120,7 @@ namespace MissingAssetsFinder
             {
                 var missingAssets = await Task.Run(async () =>
                 {
-                    using var finder = new Finder(SelectedDataPath);
+                    var finder = new Finder(SelectedDataPath);
 
                     await finder.BuildBSACacheAsync();
                     await finder.BuildLooseFileCacheAsync();

--- a/MissingAssetsFinder/MainWindowVM.cs
+++ b/MissingAssetsFinder/MainWindowVM.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reactive;
@@ -135,7 +135,7 @@ namespace MissingAssetsFinder
 
                 if(!UseLoadOrder) 
                     missingAssets.Sort((first, second) =>
-                    new Finder.FormKeyComparer().Compare(first.Record.FormKey, second.Record.FormKey));
+                        FormKey.AlphabeticalComparer().Compare(first.Record.FormKey, second.Record.FormKey));
                 MissingAssets = missingAssets;
             }
             catch (Exception e)

--- a/MissingAssetsFinder/MissingAssetsFinder.csproj
+++ b/MissingAssetsFinder/MissingAssetsFinder.csproj
@@ -12,7 +12,7 @@
   <ItemGroup>
     <PackageReference Include="JetBrains.Annotations" Version="2020.1.0" />
     <PackageReference Include="MaterialDesignThemes" Version="3.1.2" />
-    <PackageReference Include="Mutagen.Bethesda" Version="0.5.0" />
+    <PackageReference Include="Mutagen.Bethesda" Version="0.8.0" />
     <PackageReference Include="ReactiveUI" Version="11.4.1" />
     <PackageReference Include="ReactiveUI.Fody" Version="11.4.1" />
     <PackageReference Include="ReactiveUI.WPF" Version="11.4.1" />


### PR DESCRIPTION
Saw some things to improve on the Mutagen API, so did those and then did the upgrade here.
- FormKey comparers for Alphabetical and by Load Order now built in.  Alphabetical will order .esms first, but that feature can be turned off.
- LoadOrder<TMod> usage was overkill, as none of the mods imported were being used.  What you were mainly after was just the ordering of ModKeys, so `List<ModKey>` is good enough and simpler.
- Refactored TryAdd for cleaner calls (just saw the opportunity in passing)